### PR TITLE
feat: add support for baseUrl in options

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -26,7 +26,6 @@ export class GaxiosError<T = any> extends Error {
   }
 }
 
-
 export type Headers = {
   [index: string]: any
 };
@@ -44,6 +43,7 @@ export interface GaxiosResponse<T = any> {
  */
 export interface GaxiosOptions {
   url?: string;
+  baseUrl?: string;
   method?: 'GET'|'HEAD'|'POST'|'DELETE'|'PUT'|'CONNECT'|'OPTIONS'|'TRACE'|
       'PATCH';
   headers?: {[index: string]: string};
@@ -57,7 +57,6 @@ export interface GaxiosOptions {
   retryConfig?: RetryConfig;
   retry?: boolean;
 }
-
 
 /**
  * Configuration for the Gaxios `request` method.

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -101,14 +101,17 @@ export class Gaxios {
   }
 
   /**
-   * Validate the options, and massage them to match the
-   * fetch format.
+   * Validate the options, and massage them to match the fetch format.
    * @param opts The original options passed from the client.
    */
   private validateOpts(options: GaxiosOptions): GaxiosOptions {
     const opts = extend(true, {}, this.defaults, options);
     if (!opts.url) {
       throw new Error('URL is required.');
+    }
+
+    if (opts.baseUrl) {
+      opts.url = (new URL(opts.url, opts.baseUrl)).toString();
     }
 
     opts.headers = opts.headers || {};

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -64,14 +64,17 @@ describe('🥁 configuration options', () => {
     assert.strictEqual(res.config.headers!.figgy, 'pudding');
   });
 
+  it('should allow setting a base url in the options', async () => {
+    const scope = nock(url).get('/mango').reply(200, {});
+    const inst = new Gaxios({baseUrl: url});
+    const res = await inst.request({url: '/mango'});
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
+  });
+
   it('should allow overriding valid status', async () => {
     const scope = nock(url).get('/').reply(304);
-    const res = await request({
-      url,
-      validateStatus: () => {
-        return true;
-      }
-    });
+    const res = await request({url, validateStatus: () => true});
     scope.done();
     assert.strictEqual(res.status, 304);
   });


### PR DESCRIPTION
The `GaxiosOptions` object now supports a `baseUrl` property that can be used to set the base url for a request.  This is especially useful when using a single instance, and making many requests to the same domain:

```js
const gaxios = require('gaxios');
gaxios.instance.defaults.baseUrl = 'https://example.com';
gaxios.request({ url: '/data' }).then(...);
```
