### PR TITLE
feat: support request cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ gaxios.request({url: '/data'}).then(...);
   },
 
   // Enables default configuration for retries.
-  retry: boolean;
+  retry: boolean,
+
+  // Cancelling a request requires the `abort-controller` library.
+  // See https://github.com/bitinn/node-fetch#request-cancellation-with-abortsignal
+  signal?: AbortSignal
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^10.5.6",
     "@types/node-fetch": "^2.1.2",
     "@types/sinon": "^7.0.0",
+    "abort-controller": "^2.0.2",
     "assert-rejects": "^1.0.0",
     "codecov": "^3.0.4",
     "gts": "^0.9.0",

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import {Agent} from 'https';
+import {AbortSignal} from 'abort-controller';
 
 export class GaxiosError<T = any> extends Error {
   code?: string;
@@ -69,6 +70,7 @@ export interface GaxiosOptions {
   validateStatus?: (status: number) => boolean;
   retryConfig?: RetryConfig;
   retry?: boolean;
+  signal?: AbortSignal;
   size?: number;
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Agent} from 'https';
 import {AbortSignal} from 'abort-controller';
+import {Agent} from 'https';
 
 export class GaxiosError<T = any> extends Error {
   code?: string;


### PR DESCRIPTION
Fixes #31 

This is the way to cancel a request through node-fetch: https://github.com/bitinn/node-fetch#request-cancellation-with-abortsignal

In theory, we could make it easier for the user by creating a controller for each request, and return a method like "request.cancel()". Or, not. Not is what this PR does.