### PR TITLE
fix: merge querystring with params

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -126,6 +126,19 @@ export class Gaxios {
       opts.url = baseUrl + opts.url;
     }
 
+    const parsedUrl = new URL(opts.url);
+    opts.url = `${parsedUrl.origin}${parsedUrl.pathname}`;
+    opts.params = extend(
+        qs.parse(parsedUrl.search.substr(1)),  // removes leading ?
+        opts.params);
+
+    opts.paramsSerializer = opts.paramsSerializer || this.paramsSerializer;
+    if (opts.params) {
+      parsedUrl.search = opts.paramsSerializer(opts.params);
+    }
+
+    opts.url = parsedUrl.href;
+
     if (typeof options.maxContentLength === 'number') {
       opts.size = options.maxContentLength;
     }
@@ -147,18 +160,11 @@ export class Gaxios {
     }
 
     opts.validateStatus = opts.validateStatus || this.validateStatus;
-    opts.paramsSerializer = opts.paramsSerializer || this.paramsSerializer;
     opts.responseType = opts.responseType || 'json';
     if (!opts.headers['Accept'] && opts.responseType === 'json') {
       opts.headers['Accept'] = 'application/json';
     }
     opts.method = opts.method || 'GET';
-
-    if (opts.params) {
-      const parts = new URL(opts.url);
-      parts.search = opts.paramsSerializer(opts.params);
-      opts.url = parts.href;
-    }
 
     const proxy = loadProxy();
     if (proxy) {

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -123,7 +123,17 @@ describe('🥁 configuration options', () => {
     assert.strictEqual(response, res);
   });
 
-  it('should encode query string parameters', async () => {
+  it('should encode URL parameters', async () => {
+    const path = '/?james=kirk&montgomery=scott';
+    const opts = {url: `${url}${path}`};
+    const scope = nock(url).get(path).reply(200, {});
+    const res = await request(opts);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.config.url, url + path);
+    scope.done();
+  });
+
+  it('should encode parameters from the params option', async () => {
     const opts = {url, params: {james: 'kirk', montgomery: 'scott'}};
     const path = '/?james=kirk&montgomery=scott';
     const scope = nock(url).get(path).reply(200, {});
@@ -133,7 +143,7 @@ describe('🥁 configuration options', () => {
     scope.done();
   });
 
-  it('should merge URL parameters with params option', async () => {
+  it('should merge URL parameters with the params option', async () => {
     const opts = {
       url: `${url}/?james=beckwith&montgomery=scott`,
       params: {james: 'kirk'}

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -133,6 +133,19 @@ describe('🥁 configuration options', () => {
     scope.done();
   });
 
+  it('should merge URL parameters with params option', async () => {
+    const opts = {
+      url: `${url}/?james=beckwith&montgomery=scott`,
+      params: {james: 'kirk'}
+    };
+    const path = '/?james=kirk&montgomery=scott';
+    const scope = nock(url).get(path).reply(200, {});
+    const res = await request(opts);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.config.url, url + path);
+    scope.done();
+  });
+
   it('should allow overriding the param serializer', async () => {
     const qs = '?oh=HAI';
     const params = {james: 'kirk'};
@@ -140,7 +153,7 @@ describe('🥁 configuration options', () => {
       url,
       params,
       paramsSerializer: (ps) => {
-        assert.deepStrictEqual(params, ps);
+        assert.deepEqual(params, ps);
         return '?oh=HAI';
       }
     };


### PR DESCRIPTION
Previously, the `params` option would replace any query string parameters from the `url` option:

#### Before
```js
request({
  url: 'http://google.com/?search=value',
  params: {referrer: 'google'}
}) // GET http://google.com/?referrer=google
```

#### After
```js
request({
  url: 'http://google.com/?search=value',
  params: {referrer: 'google'}
}) // GET http://google.com/?search=value&referrer=google
```

`params` wins:

```js
request({
  url: 'http://google.com/?search=value',
  params: {search: 'value2'}
}) // GET http://google.com/?search=value2
```