### PR TITLE
build: enable esModuleInterop for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 coverage
 yarn.lock
 .vscode
+dist/

--- a/browser-test/browser-test-runner.ts
+++ b/browser-test/browser-test-runner.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as execa from 'execa';
-import * as express from 'express';
-import * as http from 'http';
+import execa from 'execa';
+import express from 'express';
+import http from 'http';
 
 const port = 7172;
 

--- a/browser-test/test.browser.ts
+++ b/browser-test/test.browser.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 
 import {request} from '../src/index';
 const port = 7172;  // should match the port defined in `webserver.ts`

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -13,7 +13,7 @@
 
 import extend from 'extend';
 import {Agent} from 'https';
-import fetch, {Response} from 'node-fetch';
+import nodeFetch, {Response as NodeFetchResponse} from 'node-fetch';
 import qs from 'querystring';
 import stream from 'stream';
 import url from 'url';
@@ -23,6 +23,7 @@ import {isBrowser} from './isbrowser';
 import {getRetryConfig} from './retry';
 
 const URL = isBrowser() ? window.URL : url.URL;
+const fetch = isBrowser() ? window.fetch : nodeFetch;
 
 // tslint:disable-next-line variable-name no-any
 let HttpsProxyAgent: any;
@@ -89,8 +90,8 @@ export class Gaxios {
     }
   }
 
-  private async getResponseData(opts: GaxiosOptions, res: Response):
-      Promise<any> {
+  private async getResponseData(
+      opts: GaxiosOptions, res: Response|NodeFetchResponse): Promise<any> {
     switch (opts.responseType) {
       case 'stream':
         return res.body;
@@ -199,8 +200,9 @@ export class Gaxios {
     return obj instanceof stream.Readable && typeof obj._read === 'function';
   }
 
-  private translateResponse<T>(opts: GaxiosOptions, res: Response, data?: T):
-      GaxiosResponse<T> {
+  private translateResponse<T>(
+      opts: GaxiosOptions, res: Response|NodeFetchResponse,
+      data?: T): GaxiosResponse<T> {
     // headers need to be converted from a map to an obj
     const headers = {} as Headers;
     res.headers.forEach((value, key) => {

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as extend from 'extend';
+import extend from 'extend';
 import {Agent} from 'https';
 import fetch, {Response} from 'node-fetch';
-import * as qs from 'querystring';
-import * as stream from 'stream';
-import * as url from 'url';
+import qs from 'querystring';
+import stream from 'stream';
+import url from 'url';
 
 import {GaxiosError, GaxiosOptions, GaxiosPromise, GaxiosResponse, Headers} from './common';
 import {isBrowser} from './isbrowser';

--- a/system-test/test.install.ts
+++ b/system-test/test.install.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
-import * as execa from 'execa';
-import * as fs from 'fs';
-import * as mv from 'mv';
+import assert from 'assert';
+import execa from 'execa';
+import fs from 'fs';
+import mv from 'mv';
 import {ncp} from 'ncp';
-import * as path from 'path';
-import * as tmp from 'tmp';
+import path from 'path';
+import tmp from 'tmp';
 import {promisify} from 'util';
 
 const keep = false;

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import * as nock from 'nock';
-import * as sinon from 'sinon';
-import * as stream from 'stream';
+import assert from 'assert';
+import nock from 'nock';
+import sinon from 'sinon';
+import stream from 'stream';
 const assertRejects = require('assert-rejects');
 // tslint:disable-next-line variable-name
 const HttpsProxyAgent = require('https-proxy-agent');
 import {Gaxios, GaxiosError, request, GaxiosOptions, GaxiosResponse} from '../src';
-import * as qs from 'querystring';
-import * as fs from 'fs';
+import qs from 'querystring';
+import fs from 'fs';
 import {Blob} from 'node-fetch';
 
 nock.disableNetConnect();

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -11,10 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
+import assert from 'assert';
 
 import * as main from '../src/index';
-import * as assert from 'assert';
 
 describe('📝 main exports', () => {
   it('should export all the types', () => {

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as assert from 'assert';
-import * as nock from 'nock';
+import assert from 'assert';
+import nock from 'nock';
 
 import {GaxiosError, GaxiosOptions, request} from '../src';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["es2015", "dom"],
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "esModuleInterop": true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
This enables the `esModuleInterop` flag in the `tsconfig`.  Doing this for a few reasons:
- I don't believe we export d.ts types, which can cause problems downstream
- It's the default for TypeScript's out of the box config
- It's about to be the default for `gts`