### PR TITLE
build: drop support for node.js 6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,6 @@ test_task:
       image: node:11
       image: node:10
       image: node:8
-      image: node:6
   install_script: npm install
   test_script: npm test
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "keywords": [
     "google"
   ],
+  "engines": {
+    "node": ">=8"
+  },
   "author": "Google, LLC",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: This change removes explicit support for node.js 6.x.  Versions 8.x and up will be supported.