### PR TITLE
feat: release 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaxios",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A simple common HTTP client specifically for Google APIs and services.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: This release drops support for Node.js 6.x.